### PR TITLE
Remove access to Electron API

### DIFF
--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1,8 +1,14 @@
 import { ElectronAPI } from '@electron-toolkit/preload'
 
+interface CustomAPI {
+  versions: {
+    [key: string]: string | undefined
+  }
+}
+
 declare global {
   interface Window {
     electron: ElectronAPI
-    api: unknown
+    cpClientApi: CustomAPI
   }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2,12 +2,13 @@ import { contextBridge } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
 
 // Custom APIs for renderer
-const api = {}
+const api = {
+  versions: electronAPI.process.versions
+}
 
 // Use `contextBridge` APIs to expose Electron APIs to renderer
 try {
-  contextBridge.exposeInMainWorld('electron', electronAPI)
-  contextBridge.exposeInMainWorld('api', api)
+  contextBridge.exposeInMainWorld('cpClientApi', api)
 } catch (error) {
   console.error(error)
 }

--- a/src/renderer/src/components/Versions.tsx
+++ b/src/renderer/src/components/Versions.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { Badge } from './ui/badge'
 
 function Versions(): JSX.Element {
-  const [versions] = useState(window.electron.process.versions)
+  const [versions] = useState(window.cpClientApi.versions)
   const [flashVersion] = useState<string | null>(
     navigator.plugins['Shockwave Flash']?.description.substring('Shockwave Flash '.length) || null
   )

--- a/src/renderer/src/components/Versions.tsx
+++ b/src/renderer/src/components/Versions.tsx
@@ -1,18 +1,17 @@
 import { useState } from 'react'
-
 import { Badge } from './ui/badge'
 
 function Versions(): JSX.Element {
-  const [versions] = useState(window.cpClientApi.versions)
+  const [versions] = useState(window.cpClientApi?.versions ?? {})
   const [flashVersion] = useState<string | null>(
     navigator.plugins['Shockwave Flash']?.description.substring('Shockwave Flash '.length) || null
   )
 
   return (
     <>
-      <Badge>Electron v{versions.electron}</Badge>
-      <Badge>Chromium v{versions.chrome}</Badge>
-      <Badge>Node v{versions.node}</Badge>
+      <Badge>Electron v{versions.electron || 'Unknown'}</Badge>
+      <Badge>Chromium v{versions.chrome || 'Unknown'}</Badge>
+      <Badge>Node v{versions.node || 'Unknown'}</Badge>
       {flashVersion && <Badge>Flash v{flashVersion}</Badge>}
     </>
   )


### PR DESCRIPTION
Allowing the page access to IPC and WebFrame APIs is not ideal if they're not needed. This PR removes them in favor of just exposing the versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the way version information (Electron, Chromium, Node) is accessed and displayed in the app, showing "Unknown" when versions are unavailable.

- **Refactor**
  - Improved the global API structure and naming for accessing version details, consolidating exposure under a single, clearer global property.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->